### PR TITLE
feat: PR内の本文に記載された脆弱性診断用のURL, APIがCHANGELOGの内容として出力されるように無理やり実装

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -10,6 +10,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const pMap = require("p-map");
+const marked_1 = require("marked");
 const progress_bar_1 = require("./progress-bar");
 const find_pull_request_id_1 = require("./find-pull-request-id");
 const Git = require("./git");
@@ -114,9 +115,11 @@ class Changelog {
     downloadIssueData(commitInfos) {
         return __awaiter(this, void 0, void 0, function* () {
             progress_bar_1.default.init("Downloading issue information…", commitInfos.length);
+            commitInfos = commitInfos.filter(x => x.issueNumber === '1' || x.issueNumber === null);
             yield pMap(commitInfos, (commitInfo) => __awaiter(this, void 0, void 0, function* () {
                 if (commitInfo.issueNumber) {
                     commitInfo.githubIssue = yield this.github.getIssueData(this.config.repo, commitInfo.issueNumber);
+                    commitInfo.githubIssue.parsed_body = marked_1.lexer(commitInfo.githubIssue.body);
                 }
                 progress_bar_1.default.tick();
             }), { concurrency: 5 });

--- a/lib/markdown-renderer.js
+++ b/lib/markdown-renderer.js
@@ -20,9 +20,16 @@ class MarkdownRenderer {
             return "";
         const releaseTitle = release.name === UNRELEASED_TAG ? this.options.unreleasedName : release.name;
         let markdown = `## ${releaseTitle} (${release.date})`;
+        const securityTestTarget = { urls: [], apis: [] };
         for (const category of categoriesWithCommits) {
             markdown += `\n\n#### ${category.name}\n`;
+            const target = this.getSecurityTestTarget(category.commits);
+            securityTestTarget.urls.push(...target.urls);
+            securityTestTarget.apis.push(...target.apis);
             markdown += this.renderContributionList(category.commits);
+        }
+        if (securityTestTarget.urls.length > 0 || securityTestTarget.apis.length > 0) {
+            markdown += `\n\n${this.renderSecurityTestTargetList(securityTestTarget)}`;
         }
         return markdown;
     }
@@ -67,6 +74,18 @@ class MarkdownRenderer {
             return markdown;
         }
     }
+    renderSecurityTestTargetList(securityTestTarget) {
+        let markdown = "#### 脆弱診断対象\n\n";
+        if (securityTestTarget.urls.length > 0) {
+            const rows = securityTestTarget.urls.filter(onlyUnique).sort().map(x => `* ${x}\n`).join("");
+            markdown += `##### URL\n${rows}\n`;
+        }
+        if (securityTestTarget.apis.length > 0) {
+            const rows = securityTestTarget.apis.filter(onlyUnique).sort().map(x => `* ${x}\n`).join("");
+            markdown += `##### API\n${rows}\n`;
+        }
+        return markdown;
+    }
     renderContributorList(contributors) {
         const renderedContributors = contributors.map(contributor => `- ${this.renderContributor(contributor)}`).sort();
         return `#### Committers: ${contributors.length}\n${renderedContributors.join("\n")}`;
@@ -89,5 +108,35 @@ class MarkdownRenderer {
             return { name, commits };
         });
     }
+    getSecurityTestTarget(commits) {
+        const TARGET_HEADER = '種別,診断対象';
+        return commits.reduce((acc, commit) => {
+            var _a;
+            const pared = (_a = commit.githubIssue) === null || _a === void 0 ? void 0 : _a.parsed_body;
+            if (pared !== undefined) {
+                pared.forEach(x => {
+                    if (x.type === 'table' && x.header.join() === TARGET_HEADER) {
+                        x.cells.forEach(c => {
+                            var _a, _b;
+                            const name = (_a = c[1]) !== null && _a !== void 0 ? _a : '';
+                            const type = (_b = c[0]) !== null && _b !== void 0 ? _b : '';
+                            if (name.length > 0) {
+                                if (type === 'URL') {
+                                    acc.urls.push(name);
+                                }
+                                if (['Mutation', 'Query', 'Subscription'].includes(type)) {
+                                    acc.apis.push(`(${type}) ${name}`);
+                                }
+                            }
+                        });
+                    }
+                });
+            }
+            return acc;
+        }, { apis: [], urls: [] });
+    }
 }
 exports.default = MarkdownRenderer;
+function onlyUnique(value, index, self) {
+    return self.indexOf(value) === index;
+}

--- a/package.json
+++ b/package.json
@@ -38,12 +38,14 @@
     "execa": "^1.0.0",
     "hosted-git-info": "^3.0.8",
     "make-fetch-happen": "^7.1.1",
+    "marked": "^2.0.7",
     "p-map": "^3.0.0",
     "progress": "^2.0.0",
     "yargs": "^13.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",
+    "@types/marked": "^2.0.3",
     "@types/node": "^13.13.4",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,5 +1,6 @@
 const pMap = require("p-map");
 
+import { lexer } from 'marked'
 import progressBar from "./progress-bar";
 import { Configuration } from "./configuration";
 import findPullRequestId from "./find-pull-request-id";
@@ -151,13 +152,14 @@ export default class Changelog {
 
   private async downloadIssueData(commitInfos: CommitInfo[]) {
     progressBar.init("Downloading issue information…", commitInfos.length);
+    commitInfos = commitInfos.filter(x => x.issueNumber === '1' || x.issueNumber === null)
     await pMap(
       commitInfos,
       async (commitInfo: CommitInfo) => {
         if (commitInfo.issueNumber) {
           commitInfo.githubIssue = await this.github.getIssueData(this.config.repo, commitInfo.issueNumber);
+          commitInfo.githubIssue.parsed_body = lexer(commitInfo.githubIssue.body)
         }
-
         progressBar.tick();
       },
       { concurrency: 5 }

--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -1,5 +1,6 @@
 const path = require("path");
 
+import { TokensList } from 'marked'
 import ConfigurationError from "./configuration-error";
 import fetch from "./fetch";
 
@@ -12,6 +13,8 @@ export interface GitHubUserResponse {
 export interface GitHubIssueResponse {
   number: number;
   title: string;
+  body: string;
+  parsed_body: TokensList;
   pull_request?: {
     html_url: string;
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,6 +629,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/marked@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-2.0.3.tgz#c8ea93684e530cc3b667d3e7226556dd0844ad1f"
+  integrity sha512-lbhSN1rht/tQ+dSWxawCzGgTfxe9DB31iLgiT1ZVT5lshpam/nyOA1m3tKHRoNPctB2ukSL22JZI5Fr+WI/zYg==
+
 "@types/node@*", "@types/node@^13.13.4":
   version "13.13.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.4.tgz#1581d6c16e3d4803eb079c87d4ac893ee7501c2c"
@@ -3128,6 +3133,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+marked@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.7.tgz#bc5b857a09071b48ce82a1f7304913a993d4b7d1"
+  integrity sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## やったこと

- PR内の本文に記載された脆弱性診断用のURL, APIがCHANGELOGの内容として出力されるように無理やり実装

## 脆弱性診断

| 種別 | 診断対象 |
| --- | --- |
| URL | /positions |
| URL | /managed/positions/${id}
| Mutation | createUser |
| Mutation | hogehoge |
| Subscription | hugahuga |