### PR TITLE
chore: commitを自動的にタグごとにグルーピングしてCHANGELOG.mdを生成するようになっていたがステージング環境デプロイ用のタグなどがリリース用のタグと混在している場合などは色々と問題があるのですべてのcommitがnext-versionに含まれるようにした

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -115,6 +115,7 @@ class Changelog {
     downloadIssueData(commitInfos) {
         return __awaiter(this, void 0, void 0, function* () {
             progress_bar_1.default.init("Downloading issue information…", commitInfos.length);
+            commitInfos = commitInfos.filter(x => x.issueNumber === '1' || x.issueNumber === '3' || x.issueNumber === null);
             yield pMap(commitInfos, (commitInfo) => __awaiter(this, void 0, void 0, function* () {
                 if (commitInfo.issueNumber) {
                     commitInfo.githubIssue = yield this.github.getIssueData(this.config.repo, commitInfo.issueNumber);
@@ -126,21 +127,11 @@ class Changelog {
         });
     }
     groupByRelease(commits) {
-        let releaseMap = {};
-        let currentTags = [UNRELEASED_TAG];
-        for (const commit of commits) {
-            if (commit.tags && commit.tags.length > 0) {
-                currentTags = commit.tags;
-            }
-            for (const currentTag of currentTags) {
-                if (!releaseMap[currentTag]) {
-                    let date = currentTag === UNRELEASED_TAG ? this.getToday() : commit.date;
-                    releaseMap[currentTag] = { name: currentTag, date, commits: [] };
-                }
-                releaseMap[currentTag].commits.push(commit);
-            }
-        }
-        return Object.keys(releaseMap).map(tag => releaseMap[tag]);
+        return [{
+                name: UNRELEASED_TAG,
+                date: this.getToday(),
+                commits,
+            }];
     }
     getToday() {
         const date = new Date().toISOString();

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -170,33 +170,42 @@ export default class Changelog {
   }
 
   private groupByRelease(commits: CommitInfo[]): Release[] {
-    // Analyze the commits and group them by tag.
-    // This is useful to generate multiple release logs in case there are
-    // multiple release tags.
-    let releaseMap: { [id: string]: Release } = {};
 
-    let currentTags = [UNRELEASED_TAG];
-    for (const commit of commits) {
-      if (commit.tags && commit.tags.length > 0) {
-        currentTags = commit.tags;
-      }
+    // TODO: tagのprefixかなにかで対象のタグを絞り込めるようにする。または構造をきっぱり変える。
+    // NOTE: 暫定ですべてnext-versionに含めるようにしている。
+    // // Analyze the commits and group them by tag.
+    // // This is useful to generate multiple release logs in case there are
+    // // multiple release tags.
+    // let releaseMap: { [id: string]: Release } = {};
 
-      // Tags referenced by commits are treated as a list. When grouping them,
-      // we split the commits referenced by multiple tags in their own group.
-      // This results in having one group of commits for each tag, even if
-      // the same commits are "duplicated" across the different tags
-      // referencing them.
-      for (const currentTag of currentTags) {
-        if (!releaseMap[currentTag]) {
-          let date = currentTag === UNRELEASED_TAG ? this.getToday() : commit.date;
-          releaseMap[currentTag] = { name: currentTag, date, commits: [] };
-        }
+    // let currentTags = [UNRELEASED_TAG];
+    // for (const commit of commits) {
+    //   if (commit.tags && commit.tags.length > 0) {
+    //     currentTags = commit.tags;
+    //   }
 
-        releaseMap[currentTag].commits.push(commit);
-      }
-    }
+    //   // Tags referenced by commits are treated as a list. When grouping them,
+    //   // we split the commits referenced by multiple tags in their own group.
+    //   // This results in having one group of commits for each tag, even if
+    //   // the same commits are "duplicated" across the different tags
+    //   // referencing them.
+    //   for (const currentTag of currentTags) {
+    //     if (!releaseMap[currentTag]) {
+    //       let date = currentTag === UNRELEASED_TAG ? this.getToday() : commit.date;
+    //       releaseMap[currentTag] = { name: currentTag, date, commits: [] };
+    //     }
 
-    return Object.keys(releaseMap).map(tag => releaseMap[tag]);
+    //     releaseMap[currentTag].commits.push(commit);
+    //   }
+    // }
+
+    // return Object.keys(releaseMap).map(tag => releaseMap[tag]);
+
+    return [{
+      name: UNRELEASED_TAG,
+      date: this.getToday(),
+      commits,
+    }]
   }
 
   private getToday() {


### PR DESCRIPTION
## やったこと

- タイトル通り


| 種別 | 診断対象 |
| --- | --- |
| URL | /positions |
| URL |　　      |